### PR TITLE
Docs: Add link to project planning page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,6 @@
 Thanks for taking an interest in helping to develop [bujo](https://github.com/dcchambers/bujo)!
 
 Bujo is in the early stages of development right now and is not yet ready for outside code contributions. Please consider [opening an issue](https://github.com/dcchambers/bujo/issues/new) with a feature request, or browse the [development docs on the wiki](https://github.com/dcchambers/bujo/wiki).
+
+Project planning is being done in the new GitHub Projects.
+- [bujo development](https://github.com/users/dcchambers/projects/1)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # bujo
 CLI Bullet Journal
 
-Please see the [wiki](https://github.com/dcchambers/bujo/wiki) for development and feature planning.
+- Please see the [wiki](https://github.com/dcchambers/bujo/wiki) for development and feature planning.
+- Project planning is being tracked in [GitHub Projects](https://github.com/users/dcchambers/projects/1).
 
 ## Contributing
 


### PR DESCRIPTION
Update `README.md` and `CONTRIBUTING.md` with links to the github projects page.