### PR TITLE
feat: Add task subcommand

### DIFF
--- a/cmd/task.go
+++ b/cmd/task.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// taskCmd represents the task command
+var taskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf("Enter Task: ")
+		task, _ := reader.ReadString('\n')
+		fmt.Printf(" ○ %s", task)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(taskCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// taskCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// taskCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}


### PR DESCRIPTION
Scaffolds out a `task` subcommand.
- Usage: `bujo task`
- Accepts user input with `bufio Reader.ReadString`.

Currently prints the input and quits.

Resolves #5 